### PR TITLE
Improve Date picker layout

### DIFF
--- a/Components/Generali/Calendar.tsx
+++ b/Components/Generali/Calendar.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, StyleProp, StyleSheet, TextInput, View, ViewStyle } from 'react-native';
+import useTheme from '@/hooks/useTheme';
+import BottomSheet from './BottomSheet';
+import Text from './Text';
+import Icon from './Icon';
+import { mesi } from '@/utils/DateFormat';
+
+export type CalendarProps = {
+    /** currently selected date */
+    date: Date;
+    /** callback when user selects a day */
+    onSelect: (day: Date) => void;
+    minimumDate?: Date;
+    maximumDate?: Date;
+    /** optional function to decide if a day should appear selected */
+    isSelected?: (day: Date) => boolean;
+    style?: StyleProp<ViewStyle>;
+};
+
+export default function Calendar(props: CalendarProps) {
+    const theme = useTheme();
+    const [month, setMonth] = useState(props.date.getMonth());
+    const [year, setYear] = useState(props.date.getFullYear());
+    const [yearSheet, setYearSheet] = useState(false);
+    const [yearQuery, setYearQuery] = useState('');
+    const [yearPage, setYearPage] = useState(1);
+
+    useEffect(() => {
+        setMonth(props.date.getMonth());
+        setYear(props.date.getFullYear());
+    }, [props.date]);
+
+    useEffect(() => { setYearPage(1); }, [yearQuery]);
+
+    const daysInMonth = useCallback((y: number, m: number) => new Date(y, m + 1, 0).getDate(), []);
+
+    const years = useMemo(() => {
+        const current = new Date().getFullYear();
+        const start = props.minimumDate?.getFullYear() ?? current - 100;
+        const end = props.maximumDate?.getFullYear() ?? current + 10;
+        const arr: number[] = [];
+        for (let y = start; y <= end; y++) arr.push(y);
+        return arr;
+    }, [props.minimumDate, props.maximumDate]);
+
+    const filteredYears = useMemo(() => years.filter(y => y.toString().includes(yearQuery)), [years, yearQuery]);
+    const yearPageSize = 20;
+    const displayedYears = useMemo(() => filteredYears.slice(0, yearPage * yearPageSize), [filteredYears, yearPage]);
+
+    const days = useMemo(() => Array.from({ length: daysInMonth(year, month) }, (_, i) => i + 1), [year, month, daysInMonth]);
+
+    const prevMonth = useCallback(() => {
+        setMonth(m => {
+            if (m === 0) { setYear(y => y - 1); return 11; }
+            return m - 1;
+        });
+    }, []);
+
+    const nextMonth = useCallback(() => {
+        setMonth(m => {
+            if (m === 11) { setYear(y => y + 1); return 0; }
+            return m + 1;
+        });
+    }, []);
+
+    const selectYear = useCallback((y: number) => { setYear(y); setYearSheet(false); }, []);
+
+    const onSelect = useCallback((d: number) => {
+        const selected = new Date(year, month, d);
+        props.onSelect(selected);
+    }, [year, month, props.onSelect]);
+
+    return (
+        <View style={[styles.container, props.style]}> 
+            <View style={styles.header}> 
+                <Pressable onPress={prevMonth} style={styles.arrow}><Icon name="chevron-left" size={24} /></Pressable>
+                <Pressable onPress={() => setYearSheet(true)} style={styles.monthLabel}>
+                    <Text style={styles.headerText}>{mesi[month].nome} {year}</Text>
+                </Pressable>
+                <Pressable onPress={nextMonth} style={styles.arrow}><Icon name="chevron-right" size={24} /></Pressable>
+            </View>
+            <View style={styles.daysGrid}>
+                {days.map(d => {
+                    const dateObj = new Date(year, month, d);
+                    const selected = props.isSelected ? props.isSelected(dateObj) : (props.date.getDate() === d && props.date.getMonth() === month && props.date.getFullYear() === year);
+                    return (
+                        <Pressable key={d} style={[styles.dayItem, selected && { backgroundColor: theme.colors.lineshare }]} onPress={() => onSelect(d)}>
+                            <Text style={selected ? { color: 'white' } : undefined}>{d}</Text>
+                        </Pressable>
+                    );
+                })}
+            </View>
+            <BottomSheet visible={yearSheet} onRequestClose={() => setYearSheet(false)}>
+                <View style={styles.yearContainer}>
+                    <TextInput
+                        placeholder="Cerca anno"
+                        value={yearQuery}
+                        onChangeText={setYearQuery}
+                        style={styles.searchInput}
+                        keyboardType="numeric"
+                    />
+                    <FlatList
+                        data={displayedYears}
+                        keyExtractor={item => item.toString()}
+                        onEndReached={() => { if (displayedYears.length < filteredYears.length) setYearPage(p => p + 1); }}
+                        renderItem={({ item }) => (
+                            <Pressable onPress={() => selectYear(item)} style={[styles.yearItem, item === year && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={item === year ? { color: 'white' } : undefined}>{item}</Text>
+                            </Pressable>
+                        )}
+                    />
+                </View>
+            </BottomSheet>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        alignItems: 'center',
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 10,
+    },
+    arrow: {
+        padding: 5,
+        borderRadius: 20,
+    },
+    monthLabel: {
+        flex: 1,
+        alignItems: 'center',
+    },
+    headerText: {
+        fontSize: 18,
+        fontFamily: 'Sora-Bold',
+    },
+    daysGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+    },
+    dayItem: {
+        width: 40,
+        height: 40,
+        borderRadius: 10,
+        justifyContent: 'center',
+        alignItems: 'center',
+        margin: 5,
+    },
+    yearContainer: {
+        padding: 20,
+    },
+    searchInput: {
+        borderWidth: 1,
+        borderRadius: 10,
+        paddingHorizontal: 10,
+        marginBottom: 10,
+    },
+    yearItem: {
+        paddingVertical: 10,
+        paddingHorizontal: 15,
+        borderRadius: 10,
+        marginVertical: 5,
+    },
+});

--- a/Components/Generali/DatePicker.tsx
+++ b/Components/Generali/DatePicker.tsx
@@ -2,9 +2,10 @@ import BottomSheet from "./BottomSheet";
 import Button, { useButtonText } from "./Button";
 import Text from "./Text";
 import useTheme from "@/hooks/useTheme";
-import { DateFormat, mesi } from "@/utils/DateFormat";
-import React, { useCallback, useMemo, useState, useEffect } from "react";
-import { FlatList, Pressable, ScrollView, StyleProp, StyleSheet, TextInput, View, ViewStyle } from "react-native";
+import { DateFormat } from "@/utils/DateFormat";
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, StyleProp, StyleSheet, View, ViewStyle } from "react-native";
+import Calendar from "./Calendar";
 
 export type DatePickerProps = {
     value?: Date;
@@ -19,13 +20,6 @@ export default function DatePicker(props: DatePickerProps) {
     const theme = useTheme();
     const [visible, setVisible] = useState(false);
     const [temp, setTemp] = useState<Date>(props.value ?? new Date());
-    const [yearSheet, setYearSheet] = useState(false);
-    const [yearQuery, setYearQuery] = useState("");
-    const [yearPage, setYearPage] = useState(1);
-
-    useEffect(() => {
-        setYearPage(1);
-    }, [yearQuery]);
 
     const display = useMemo(() => {
         if (props.value) return DateFormat.numericFormat(props.value);
@@ -34,8 +28,6 @@ export default function DatePicker(props: DatePickerProps) {
 
     const open = useCallback(() => {
         setTemp(props.value ?? new Date());
-        setYearQuery("");
-        setYearPage(1);
         setVisible(true);
     }, [props.value]);
 
@@ -44,53 +36,9 @@ export default function DatePicker(props: DatePickerProps) {
         props.onChange?.(temp);
     }, [temp, props.onChange]);
 
-    const daysInMonth = useCallback((year: number, month: number) => {
-        return new Date(year, month + 1, 0).getDate();
+    const onSelect = useCallback((d: Date) => {
+        setTemp(d);
     }, []);
-
-    const years = useMemo(() => {
-        const currentYear = new Date().getFullYear();
-        const start = props.minimumDate?.getFullYear() ?? currentYear - 100;
-        const end = props.maximumDate?.getFullYear() ?? currentYear + 10;
-        const arr: number[] = [];
-        for (let y = start; y <= end; y++) arr.push(y);
-        return arr;
-    }, [props.minimumDate, props.maximumDate]);
-
-    const filteredYears = useMemo(() => {
-        return years.filter((y) => y.toString().includes(yearQuery));
-    }, [years, yearQuery]);
-
-    const yearPageSize = 20;
-    const displayedYears = useMemo(() => {
-        return filteredYears.slice(0, yearPage * yearPageSize);
-    }, [filteredYears, yearPage]);
-
-    const days = useMemo(() => {
-        return Array.from({ length: daysInMonth(temp.getFullYear(), temp.getMonth()) }, (_, i) => i + 1);
-    }, [temp, daysInMonth]);
-
-    const selectDay = useCallback((d: number) => {
-        const date = new Date(temp);
-        date.setDate(d);
-        setTemp(date);
-    }, [temp]);
-
-    const selectMonth = useCallback((m: number) => {
-        const date = new Date(temp);
-        const day = date.getDate();
-        const daysCount = daysInMonth(date.getFullYear(), m);
-        date.setMonth(m, Math.min(day, daysCount));
-        setTemp(date);
-    }, [temp, daysInMonth]);
-
-    const selectYear = useCallback((y: number) => {
-        const date = new Date(temp);
-        const day = date.getDate();
-        const daysCount = daysInMonth(y, date.getMonth());
-        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
-        setTemp(date);
-    }, [temp, daysInMonth]);
 
     return (
         <>
@@ -102,23 +50,12 @@ export default function DatePicker(props: DatePickerProps) {
             </Pressable>
             <BottomSheet visible={visible} onRequestClose={() => setVisible(false)}>
                 <View style={styles.pickerContainer}>
-                    <Pressable onPress={() => setYearSheet(true)}>
-                        <Text style={styles.yearLabel}>{temp.getFullYear()}</Text>
-                    </Pressable>
-                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
-                        {mesi.map((m, idx) => (
-                            <Pressable key={"m" + idx} onPress={() => selectMonth(idx)} style={[styles.item, idx === temp.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={idx === temp.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
-                            </Pressable>
-                        ))}
-                    </ScrollView>
-                    <View style={styles.daysGrid}>
-                        {days.map((d) => (
-                            <Pressable key={"d" + d} onPress={() => selectDay(d)} style={[styles.dayItem, d === temp.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={d === temp.getDate() ? { color: "white" } : undefined}>{d}</Text>
-                            </Pressable>
-                        ))}
-                    </View>
+                    <Calendar
+                        date={temp}
+                        onSelect={onSelect}
+                        minimumDate={props.minimumDate}
+                        maximumDate={props.maximumDate}
+                    />
                     <View style={styles.buttonContainer}>
                         <Button onPress={confirm} width={150}>
                             <Text style={useButtonText()}>Conferma</Text>
@@ -127,35 +64,6 @@ export default function DatePicker(props: DatePickerProps) {
                 </View>
             </BottomSheet>
 
-            <BottomSheet visible={yearSheet} onRequestClose={() => setYearSheet(false)}>
-                <View style={styles.yearContainer}>
-                    <TextInput
-                        placeholder="Cerca anno"
-                        value={yearQuery}
-                        onChangeText={setYearQuery}
-                        style={styles.searchInput}
-                        keyboardType="numeric"
-                    />
-                    <FlatList
-                        data={displayedYears}
-                        keyExtractor={(item) => item.toString()}
-                        onEndReached={() => {
-                            if (displayedYears.length < filteredYears.length) setYearPage((p) => p + 1);
-                        }}
-                        renderItem={({ item }) => (
-                            <Pressable
-                                style={[styles.yearItem, item === temp.getFullYear() && { backgroundColor: theme.colors.lineshare }]}
-                                onPress={() => {
-                                    selectYear(item);
-                                    setYearSheet(false);
-                                }}
-                            >
-                                <Text style={item === temp.getFullYear() ? { color: "white" } : undefined}>{item}</Text>
-                            </Pressable>
-                        )}
-                    />
-                </View>
-            </BottomSheet>
         </>
     );
 }
@@ -175,51 +83,5 @@ const styles = StyleSheet.create({
     buttonContainer: {
         marginTop: 20,
         alignItems: "center",
-    },
-    selectRow: {
-        flexDirection: "row",
-        columnGap: 10,
-    },
-    selectScroll: {
-        flexGrow: 0,
-    },
-    item: {
-        paddingVertical: 10,
-        paddingHorizontal: 15,
-        borderRadius: 10,
-        marginHorizontal: 5,
-    },
-    yearLabel: {
-        fontSize: 18,
-        fontFamily: "Sora-Bold",
-        marginBottom: 10,
-    },
-    daysGrid: {
-        flexDirection: "row",
-        flexWrap: "wrap",
-        justifyContent: "center",
-    },
-    dayItem: {
-        width: 40,
-        height: 40,
-        borderRadius: 10,
-        justifyContent: "center",
-        alignItems: "center",
-        margin: 5,
-    },
-    yearContainer: {
-        padding: 20,
-    },
-    searchInput: {
-        borderWidth: 1,
-        borderRadius: 10,
-        paddingHorizontal: 10,
-        marginBottom: 10,
-    },
-    yearItem: {
-        paddingVertical: 10,
-        paddingHorizontal: 15,
-        borderRadius: 10,
-        marginVertical: 5,
     },
 });

--- a/Components/Generali/DatePicker.tsx
+++ b/Components/Generali/DatePicker.tsx
@@ -1,0 +1,225 @@
+import BottomSheet from "./BottomSheet";
+import Button, { useButtonText } from "./Button";
+import Text from "./Text";
+import useTheme from "@/hooks/useTheme";
+import { DateFormat, mesi } from "@/utils/DateFormat";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
+import { FlatList, Pressable, ScrollView, StyleProp, StyleSheet, TextInput, View, ViewStyle } from "react-native";
+
+export type DatePickerProps = {
+    value?: Date;
+    onChange?: (date: Date) => void;
+    placeholder?: string;
+    minimumDate?: Date;
+    maximumDate?: Date;
+    style?: StyleProp<ViewStyle>;
+};
+
+export default function DatePicker(props: DatePickerProps) {
+    const theme = useTheme();
+    const [visible, setVisible] = useState(false);
+    const [temp, setTemp] = useState<Date>(props.value ?? new Date());
+    const [yearSheet, setYearSheet] = useState(false);
+    const [yearQuery, setYearQuery] = useState("");
+    const [yearPage, setYearPage] = useState(1);
+
+    useEffect(() => {
+        setYearPage(1);
+    }, [yearQuery]);
+
+    const display = useMemo(() => {
+        if (props.value) return DateFormat.numericFormat(props.value);
+        return props.placeholder ?? "";
+    }, [props.value, props.placeholder]);
+
+    const open = useCallback(() => {
+        setTemp(props.value ?? new Date());
+        setYearQuery("");
+        setYearPage(1);
+        setVisible(true);
+    }, [props.value]);
+
+    const confirm = useCallback(() => {
+        setVisible(false);
+        props.onChange?.(temp);
+    }, [temp, props.onChange]);
+
+    const daysInMonth = useCallback((year: number, month: number) => {
+        return new Date(year, month + 1, 0).getDate();
+    }, []);
+
+    const years = useMemo(() => {
+        const currentYear = new Date().getFullYear();
+        const start = props.minimumDate?.getFullYear() ?? currentYear - 100;
+        const end = props.maximumDate?.getFullYear() ?? currentYear + 10;
+        const arr: number[] = [];
+        for (let y = start; y <= end; y++) arr.push(y);
+        return arr;
+    }, [props.minimumDate, props.maximumDate]);
+
+    const filteredYears = useMemo(() => {
+        return years.filter((y) => y.toString().includes(yearQuery));
+    }, [years, yearQuery]);
+
+    const yearPageSize = 20;
+    const displayedYears = useMemo(() => {
+        return filteredYears.slice(0, yearPage * yearPageSize);
+    }, [filteredYears, yearPage]);
+
+    const days = useMemo(() => {
+        return Array.from({ length: daysInMonth(temp.getFullYear(), temp.getMonth()) }, (_, i) => i + 1);
+    }, [temp, daysInMonth]);
+
+    const selectDay = useCallback((d: number) => {
+        const date = new Date(temp);
+        date.setDate(d);
+        setTemp(date);
+    }, [temp]);
+
+    const selectMonth = useCallback((m: number) => {
+        const date = new Date(temp);
+        const day = date.getDate();
+        const daysCount = daysInMonth(date.getFullYear(), m);
+        date.setMonth(m, Math.min(day, daysCount));
+        setTemp(date);
+    }, [temp, daysInMonth]);
+
+    const selectYear = useCallback((y: number) => {
+        const date = new Date(temp);
+        const day = date.getDate();
+        const daysCount = daysInMonth(y, date.getMonth());
+        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
+        setTemp(date);
+    }, [temp, daysInMonth]);
+
+    return (
+        <>
+            <Pressable
+                style={[styles.container, { backgroundColor: theme.colors.secondary }, props.style]}
+                onPress={open}
+            >
+                <Text>{display}</Text>
+            </Pressable>
+            <BottomSheet visible={visible} onRequestClose={() => setVisible(false)}>
+                <View style={styles.pickerContainer}>
+                    <Pressable onPress={() => setYearSheet(true)}>
+                        <Text style={styles.yearLabel}>{temp.getFullYear()}</Text>
+                    </Pressable>
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
+                        {mesi.map((m, idx) => (
+                            <Pressable key={"m" + idx} onPress={() => selectMonth(idx)} style={[styles.item, idx === temp.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={idx === temp.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+                    <View style={styles.daysGrid}>
+                        {days.map((d) => (
+                            <Pressable key={"d" + d} onPress={() => selectDay(d)} style={[styles.dayItem, d === temp.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={d === temp.getDate() ? { color: "white" } : undefined}>{d}</Text>
+                            </Pressable>
+                        ))}
+                    </View>
+                    <View style={styles.buttonContainer}>
+                        <Button onPress={confirm} width={150}>
+                            <Text style={useButtonText()}>Conferma</Text>
+                        </Button>
+                    </View>
+                </View>
+            </BottomSheet>
+
+            <BottomSheet visible={yearSheet} onRequestClose={() => setYearSheet(false)}>
+                <View style={styles.yearContainer}>
+                    <TextInput
+                        placeholder="Cerca anno"
+                        value={yearQuery}
+                        onChangeText={setYearQuery}
+                        style={styles.searchInput}
+                        keyboardType="numeric"
+                    />
+                    <FlatList
+                        data={displayedYears}
+                        keyExtractor={(item) => item.toString()}
+                        onEndReached={() => {
+                            if (displayedYears.length < filteredYears.length) setYearPage((p) => p + 1);
+                        }}
+                        renderItem={({ item }) => (
+                            <Pressable
+                                style={[styles.yearItem, item === temp.getFullYear() && { backgroundColor: theme.colors.lineshare }]}
+                                onPress={() => {
+                                    selectYear(item);
+                                    setYearSheet(false);
+                                }}
+                            >
+                                <Text style={item === temp.getFullYear() ? { color: "white" } : undefined}>{item}</Text>
+                            </Pressable>
+                        )}
+                    />
+                </View>
+            </BottomSheet>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 15,
+        borderRadius: 20,
+        height: 50,
+    },
+    pickerContainer: {
+        padding: 20,
+        alignItems: "center",
+    },
+    buttonContainer: {
+        marginTop: 20,
+        alignItems: "center",
+    },
+    selectRow: {
+        flexDirection: "row",
+        columnGap: 10,
+    },
+    selectScroll: {
+        flexGrow: 0,
+    },
+    item: {
+        paddingVertical: 10,
+        paddingHorizontal: 15,
+        borderRadius: 10,
+        marginHorizontal: 5,
+    },
+    yearLabel: {
+        fontSize: 18,
+        fontFamily: "Sora-Bold",
+        marginBottom: 10,
+    },
+    daysGrid: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        justifyContent: "center",
+    },
+    dayItem: {
+        width: 40,
+        height: 40,
+        borderRadius: 10,
+        justifyContent: "center",
+        alignItems: "center",
+        margin: 5,
+    },
+    yearContainer: {
+        padding: 20,
+    },
+    searchInput: {
+        borderWidth: 1,
+        borderRadius: 10,
+        paddingHorizontal: 10,
+        marginBottom: 10,
+    },
+    yearItem: {
+        paddingVertical: 10,
+        paddingHorizontal: 15,
+        borderRadius: 10,
+        marginVertical: 5,
+    },
+});

--- a/Components/Generali/RangeDatePicker.tsx
+++ b/Components/Generali/RangeDatePicker.tsx
@@ -2,9 +2,10 @@ import BottomSheet from "./BottomSheet";
 import Button, { useButtonText } from "./Button";
 import Text from "./Text";
 import useTheme from "@/hooks/useTheme";
-import { DateFormat, mesi } from "@/utils/DateFormat";
-import React, { useCallback, useMemo, useState, useEffect } from "react";
-import { FlatList, Pressable, ScrollView, StyleProp, StyleSheet, TextInput, View, ViewStyle } from "react-native";
+import { DateFormat } from "@/utils/DateFormat";
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, StyleProp, StyleSheet, View, ViewStyle } from "react-native";
+import Calendar from "./Calendar";
 
 export type DateRange = {
     startDate?: Date;
@@ -23,15 +24,8 @@ export type RangeDatePickerProps = {
 export default function RangeDatePicker(props: RangeDatePickerProps) {
     const theme = useTheme();
     const [visible, setVisible] = useState(false);
-    const [start, setStart] = useState<Date>(props.value?.startDate ?? new Date());
-    const [end, setEnd] = useState<Date>(props.value?.endDate ?? new Date());
-    const [yearSheet, setYearSheet] = useState<"start" | "end" | undefined>(undefined);
-    const [yearQuery, setYearQuery] = useState("");
-    const [yearPage, setYearPage] = useState(1);
-
-    useEffect(() => {
-        setYearPage(1);
-    }, [yearQuery]);
+    const [start, setStart] = useState<Date | undefined>(props.value?.startDate);
+    const [end, setEnd] = useState<Date | undefined>(props.value?.endDate);
 
     const display = useMemo(() => {
         if (props.value?.startDate && props.value?.endDate) {
@@ -45,92 +39,39 @@ export default function RangeDatePicker(props: RangeDatePickerProps) {
     }, [props.value, props.placeholder]);
 
     const open = useCallback(() => {
-        setStart(props.value?.startDate ?? new Date());
-        setEnd(props.value?.endDate ?? new Date());
-        setYearSheet(undefined);
-        setYearQuery("");
-        setYearPage(1);
+        setStart(props.value?.startDate);
+        setEnd(props.value?.endDate);
         setVisible(true);
     }, [props.value]);
-
-    const daysInMonth = useCallback((year: number, month: number) => {
-        return new Date(year, month + 1, 0).getDate();
-    }, []);
-
-    const years = useMemo(() => {
-        const currentYear = new Date().getFullYear();
-        const startY = props.minimumDate?.getFullYear() ?? currentYear - 100;
-        const endY = props.maximumDate?.getFullYear() ?? currentYear + 10;
-        const arr: number[] = [];
-        for (let y = startY; y <= endY; y++) arr.push(y);
-        return arr;
-    }, [props.minimumDate, props.maximumDate]);
-
-    const filteredYears = useMemo(() => {
-        return years.filter((y) => y.toString().includes(yearQuery));
-    }, [years, yearQuery]);
-
-    const yearPageSize = 20;
-    const displayedYears = useMemo(() => {
-        return filteredYears.slice(0, yearPage * yearPageSize);
-    }, [filteredYears, yearPage]);
-
-    const daysStart = useMemo(() => {
-        return Array.from({ length: daysInMonth(start.getFullYear(), start.getMonth()) }, (_, i) => i + 1);
-    }, [start, daysInMonth]);
-
-    const daysEnd = useMemo(() => {
-        return Array.from({ length: daysInMonth(end.getFullYear(), end.getMonth()) }, (_, i) => i + 1);
-    }, [end, daysInMonth]);
-
-    const selectDayStart = useCallback((d: number) => {
-        const date = new Date(start);
-        date.setDate(d);
-        setStart(date);
-    }, [start]);
-
-    const selectMonthStart = useCallback((m: number) => {
-        const date = new Date(start);
-        const day = date.getDate();
-        const daysCount = daysInMonth(date.getFullYear(), m);
-        date.setMonth(m, Math.min(day, daysCount));
-        setStart(date);
-    }, [start, daysInMonth]);
-
-    const selectYearStart = useCallback((y: number) => {
-        const date = new Date(start);
-        const day = date.getDate();
-        const daysCount = daysInMonth(y, date.getMonth());
-        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
-        setStart(date);
-    }, [start, daysInMonth]);
-
-    const selectDayEnd = useCallback((d: number) => {
-        const date = new Date(end);
-        date.setDate(d);
-        setEnd(date);
-    }, [end]);
-
-    const selectMonthEnd = useCallback((m: number) => {
-        const date = new Date(end);
-        const day = date.getDate();
-        const daysCount = daysInMonth(date.getFullYear(), m);
-        date.setMonth(m, Math.min(day, daysCount));
-        setEnd(date);
-    }, [end, daysInMonth]);
-
-    const selectYearEnd = useCallback((y: number) => {
-        const date = new Date(end);
-        const day = date.getDate();
-        const daysCount = daysInMonth(y, date.getMonth());
-        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
-        setEnd(date);
-    }, [end, daysInMonth]);
 
     const confirm = useCallback(() => {
         setVisible(false);
         props.onChange?.({ startDate: start, endDate: end });
     }, [start, end, props.onChange]);
+
+    const onSelect = useCallback((d: Date) => {
+        if (start && !end) {
+            if (d.getTime() < start.getTime()) {
+                setEnd(start);
+                setStart(d);
+            } else {
+                setEnd(d);
+            }
+        } else {
+            setStart(d);
+            setEnd(undefined);
+        }
+    }, [start, end]);
+
+    const isSelected = useCallback((day: Date) => {
+        if (start && end) {
+            const min = start.getTime() < end.getTime() ? start : end;
+            const max = start.getTime() < end.getTime() ? end : start;
+            return day.getTime() >= min.getTime() && day.getTime() <= max.getTime();
+        }
+        if (start && !end) return day.toDateString() === start.toDateString();
+        return false;
+    }, [start, end]);
 
     return (
         <>
@@ -142,78 +83,18 @@ export default function RangeDatePicker(props: RangeDatePickerProps) {
             </Pressable>
             <BottomSheet visible={visible} onRequestClose={() => setVisible(false)}>
                 <View style={styles.pickerContainer}>
-                    <Text style={styles.label}>Dal</Text>
-                    <Pressable onPress={() => setYearSheet('start')}>
-                        <Text style={styles.yearLabel}>{start.getFullYear()}</Text>
-                    </Pressable>
-                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
-                        {mesi.map((m, idx) => (
-                            <Pressable key={"sm" + idx} onPress={() => selectMonthStart(idx)} style={[styles.item, idx === start.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={idx === start.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
-                            </Pressable>
-                        ))}
-                    </ScrollView>
-                    <View style={styles.daysGrid}> 
-                        {daysStart.map((d) => (
-                            <Pressable key={"sd" + d} onPress={() => selectDayStart(d)} style={[styles.dayItem, d === start.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={d === start.getDate() ? { color: "white" } : undefined}>{d}</Text>
-                            </Pressable>
-                        ))}
-                    </View>
-
-                    <Text style={[styles.label, { marginTop: 20 }]}>Al</Text>
-                    <Pressable onPress={() => setYearSheet('end')}>
-                        <Text style={styles.yearLabel}>{end.getFullYear()}</Text>
-                    </Pressable>
-                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
-                        {mesi.map((m, idx) => (
-                            <Pressable key={"em" + idx} onPress={() => selectMonthEnd(idx)} style={[styles.item, idx === end.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={idx === end.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
-                            </Pressable>
-                        ))}
-                    </ScrollView>
-                    <View style={styles.daysGrid}> 
-                        {daysEnd.map((d) => (
-                            <Pressable key={"ed" + d} onPress={() => selectDayEnd(d)} style={[styles.dayItem, d === end.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
-                                <Text style={d === end.getDate() ? { color: "white" } : undefined}>{d}</Text>
-                            </Pressable>
-                        ))}
-                    </View>
+                    <Calendar
+                        date={end ?? start ?? new Date()}
+                        onSelect={onSelect}
+                        minimumDate={props.minimumDate}
+                        maximumDate={props.maximumDate}
+                        isSelected={isSelected}
+                    />
                     <View style={styles.buttonContainer}>
                         <Button onPress={confirm} width={150}>
                             <Text style={useButtonText()}>Conferma</Text>
                         </Button>
                     </View>
-                </View>
-            </BottomSheet>
-
-            <BottomSheet visible={yearSheet !== undefined} onRequestClose={() => setYearSheet(undefined)}>
-                <View style={styles.yearContainer}>
-                    <TextInput
-                        placeholder="Cerca anno"
-                        value={yearQuery}
-                        onChangeText={setYearQuery}
-                        style={styles.searchInput}
-                        keyboardType="numeric"
-                    />
-                    <FlatList
-                        data={displayedYears}
-                        keyExtractor={(item) => item.toString()}
-                        onEndReached={() => {
-                            if (displayedYears.length < filteredYears.length) setYearPage((p) => p + 1);
-                        }}
-                        renderItem={({ item }) => (
-                            <Pressable
-                                style={[styles.yearItem, item === (yearSheet === 'start' ? start.getFullYear() : end.getFullYear()) && { backgroundColor: theme.colors.lineshare }]}
-                                onPress={() => {
-                                    if (yearSheet === 'start') selectYearStart(item); else selectYearEnd(item);
-                                    setYearSheet(undefined);
-                                }}
-                            >
-                                <Text style={item === (yearSheet === 'start' ? start.getFullYear() : end.getFullYear()) ? { color: 'white' } : undefined}>{item}</Text>
-                            </Pressable>
-                        )}
-                    />
                 </View>
             </BottomSheet>
         </>
@@ -232,59 +113,8 @@ const styles = StyleSheet.create({
         padding: 20,
         alignItems: "center",
     },
-    label: {
-        fontSize: 16,
-        fontFamily: "Sora-Bold",
-        marginBottom: 10,
-    },
     buttonContainer: {
         marginTop: 20,
         alignItems: "center",
-    },
-    selectRow: {
-        flexDirection: "row",
-        columnGap: 10,
-    },
-    selectScroll: {
-        flexGrow: 0,
-    },
-    item: {
-        paddingVertical: 10,
-        paddingHorizontal: 15,
-        borderRadius: 10,
-        marginHorizontal: 5,
-    },
-    yearLabel: {
-        fontSize: 18,
-        fontFamily: "Sora-Bold",
-        marginBottom: 10,
-    },
-    daysGrid: {
-        flexDirection: "row",
-        flexWrap: "wrap",
-        justifyContent: "center",
-    },
-    dayItem: {
-        width: 40,
-        height: 40,
-        borderRadius: 10,
-        justifyContent: "center",
-        alignItems: "center",
-        margin: 5,
-    },
-    yearContainer: {
-        padding: 20,
-    },
-    searchInput: {
-        borderWidth: 1,
-        borderRadius: 10,
-        paddingHorizontal: 10,
-        marginBottom: 10,
-    },
-    yearItem: {
-        paddingVertical: 10,
-        paddingHorizontal: 15,
-        borderRadius: 10,
-        marginVertical: 5,
     },
 });

--- a/Components/Generali/RangeDatePicker.tsx
+++ b/Components/Generali/RangeDatePicker.tsx
@@ -1,0 +1,290 @@
+import BottomSheet from "./BottomSheet";
+import Button, { useButtonText } from "./Button";
+import Text from "./Text";
+import useTheme from "@/hooks/useTheme";
+import { DateFormat, mesi } from "@/utils/DateFormat";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
+import { FlatList, Pressable, ScrollView, StyleProp, StyleSheet, TextInput, View, ViewStyle } from "react-native";
+
+export type DateRange = {
+    startDate?: Date;
+    endDate?: Date;
+};
+
+export type RangeDatePickerProps = {
+    value?: DateRange;
+    onChange?: (range: DateRange) => void;
+    placeholder?: string;
+    minimumDate?: Date;
+    maximumDate?: Date;
+    style?: StyleProp<ViewStyle>;
+};
+
+export default function RangeDatePicker(props: RangeDatePickerProps) {
+    const theme = useTheme();
+    const [visible, setVisible] = useState(false);
+    const [start, setStart] = useState<Date>(props.value?.startDate ?? new Date());
+    const [end, setEnd] = useState<Date>(props.value?.endDate ?? new Date());
+    const [yearSheet, setYearSheet] = useState<"start" | "end" | undefined>(undefined);
+    const [yearQuery, setYearQuery] = useState("");
+    const [yearPage, setYearPage] = useState(1);
+
+    useEffect(() => {
+        setYearPage(1);
+    }, [yearQuery]);
+
+    const display = useMemo(() => {
+        if (props.value?.startDate && props.value?.endDate) {
+            return (
+                DateFormat.numericFormat(props.value.startDate) +
+                " - " +
+                DateFormat.numericFormat(props.value.endDate)
+            );
+        }
+        return props.placeholder ?? "";
+    }, [props.value, props.placeholder]);
+
+    const open = useCallback(() => {
+        setStart(props.value?.startDate ?? new Date());
+        setEnd(props.value?.endDate ?? new Date());
+        setYearSheet(undefined);
+        setYearQuery("");
+        setYearPage(1);
+        setVisible(true);
+    }, [props.value]);
+
+    const daysInMonth = useCallback((year: number, month: number) => {
+        return new Date(year, month + 1, 0).getDate();
+    }, []);
+
+    const years = useMemo(() => {
+        const currentYear = new Date().getFullYear();
+        const startY = props.minimumDate?.getFullYear() ?? currentYear - 100;
+        const endY = props.maximumDate?.getFullYear() ?? currentYear + 10;
+        const arr: number[] = [];
+        for (let y = startY; y <= endY; y++) arr.push(y);
+        return arr;
+    }, [props.minimumDate, props.maximumDate]);
+
+    const filteredYears = useMemo(() => {
+        return years.filter((y) => y.toString().includes(yearQuery));
+    }, [years, yearQuery]);
+
+    const yearPageSize = 20;
+    const displayedYears = useMemo(() => {
+        return filteredYears.slice(0, yearPage * yearPageSize);
+    }, [filteredYears, yearPage]);
+
+    const daysStart = useMemo(() => {
+        return Array.from({ length: daysInMonth(start.getFullYear(), start.getMonth()) }, (_, i) => i + 1);
+    }, [start, daysInMonth]);
+
+    const daysEnd = useMemo(() => {
+        return Array.from({ length: daysInMonth(end.getFullYear(), end.getMonth()) }, (_, i) => i + 1);
+    }, [end, daysInMonth]);
+
+    const selectDayStart = useCallback((d: number) => {
+        const date = new Date(start);
+        date.setDate(d);
+        setStart(date);
+    }, [start]);
+
+    const selectMonthStart = useCallback((m: number) => {
+        const date = new Date(start);
+        const day = date.getDate();
+        const daysCount = daysInMonth(date.getFullYear(), m);
+        date.setMonth(m, Math.min(day, daysCount));
+        setStart(date);
+    }, [start, daysInMonth]);
+
+    const selectYearStart = useCallback((y: number) => {
+        const date = new Date(start);
+        const day = date.getDate();
+        const daysCount = daysInMonth(y, date.getMonth());
+        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
+        setStart(date);
+    }, [start, daysInMonth]);
+
+    const selectDayEnd = useCallback((d: number) => {
+        const date = new Date(end);
+        date.setDate(d);
+        setEnd(date);
+    }, [end]);
+
+    const selectMonthEnd = useCallback((m: number) => {
+        const date = new Date(end);
+        const day = date.getDate();
+        const daysCount = daysInMonth(date.getFullYear(), m);
+        date.setMonth(m, Math.min(day, daysCount));
+        setEnd(date);
+    }, [end, daysInMonth]);
+
+    const selectYearEnd = useCallback((y: number) => {
+        const date = new Date(end);
+        const day = date.getDate();
+        const daysCount = daysInMonth(y, date.getMonth());
+        date.setFullYear(y, date.getMonth(), Math.min(day, daysCount));
+        setEnd(date);
+    }, [end, daysInMonth]);
+
+    const confirm = useCallback(() => {
+        setVisible(false);
+        props.onChange?.({ startDate: start, endDate: end });
+    }, [start, end, props.onChange]);
+
+    return (
+        <>
+            <Pressable
+                style={[styles.container, { backgroundColor: theme.colors.secondary }, props.style]}
+                onPress={open}
+            >
+                <Text>{display}</Text>
+            </Pressable>
+            <BottomSheet visible={visible} onRequestClose={() => setVisible(false)}>
+                <View style={styles.pickerContainer}>
+                    <Text style={styles.label}>Dal</Text>
+                    <Pressable onPress={() => setYearSheet('start')}>
+                        <Text style={styles.yearLabel}>{start.getFullYear()}</Text>
+                    </Pressable>
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
+                        {mesi.map((m, idx) => (
+                            <Pressable key={"sm" + idx} onPress={() => selectMonthStart(idx)} style={[styles.item, idx === start.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={idx === start.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+                    <View style={styles.daysGrid}> 
+                        {daysStart.map((d) => (
+                            <Pressable key={"sd" + d} onPress={() => selectDayStart(d)} style={[styles.dayItem, d === start.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={d === start.getDate() ? { color: "white" } : undefined}>{d}</Text>
+                            </Pressable>
+                        ))}
+                    </View>
+
+                    <Text style={[styles.label, { marginTop: 20 }]}>Al</Text>
+                    <Pressable onPress={() => setYearSheet('end')}>
+                        <Text style={styles.yearLabel}>{end.getFullYear()}</Text>
+                    </Pressable>
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={[styles.selectScroll, { marginVertical: 10 }]}> 
+                        {mesi.map((m, idx) => (
+                            <Pressable key={"em" + idx} onPress={() => selectMonthEnd(idx)} style={[styles.item, idx === end.getMonth() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={idx === end.getMonth() ? { color: "white" } : undefined}>{m.nome.slice(0,3)}</Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+                    <View style={styles.daysGrid}> 
+                        {daysEnd.map((d) => (
+                            <Pressable key={"ed" + d} onPress={() => selectDayEnd(d)} style={[styles.dayItem, d === end.getDate() && { backgroundColor: theme.colors.lineshare }]}> 
+                                <Text style={d === end.getDate() ? { color: "white" } : undefined}>{d}</Text>
+                            </Pressable>
+                        ))}
+                    </View>
+                    <View style={styles.buttonContainer}>
+                        <Button onPress={confirm} width={150}>
+                            <Text style={useButtonText()}>Conferma</Text>
+                        </Button>
+                    </View>
+                </View>
+            </BottomSheet>
+
+            <BottomSheet visible={yearSheet !== undefined} onRequestClose={() => setYearSheet(undefined)}>
+                <View style={styles.yearContainer}>
+                    <TextInput
+                        placeholder="Cerca anno"
+                        value={yearQuery}
+                        onChangeText={setYearQuery}
+                        style={styles.searchInput}
+                        keyboardType="numeric"
+                    />
+                    <FlatList
+                        data={displayedYears}
+                        keyExtractor={(item) => item.toString()}
+                        onEndReached={() => {
+                            if (displayedYears.length < filteredYears.length) setYearPage((p) => p + 1);
+                        }}
+                        renderItem={({ item }) => (
+                            <Pressable
+                                style={[styles.yearItem, item === (yearSheet === 'start' ? start.getFullYear() : end.getFullYear()) && { backgroundColor: theme.colors.lineshare }]}
+                                onPress={() => {
+                                    if (yearSheet === 'start') selectYearStart(item); else selectYearEnd(item);
+                                    setYearSheet(undefined);
+                                }}
+                            >
+                                <Text style={item === (yearSheet === 'start' ? start.getFullYear() : end.getFullYear()) ? { color: 'white' } : undefined}>{item}</Text>
+                            </Pressable>
+                        )}
+                    />
+                </View>
+            </BottomSheet>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 15,
+        borderRadius: 20,
+        height: 50,
+    },
+    pickerContainer: {
+        padding: 20,
+        alignItems: "center",
+    },
+    label: {
+        fontSize: 16,
+        fontFamily: "Sora-Bold",
+        marginBottom: 10,
+    },
+    buttonContainer: {
+        marginTop: 20,
+        alignItems: "center",
+    },
+    selectRow: {
+        flexDirection: "row",
+        columnGap: 10,
+    },
+    selectScroll: {
+        flexGrow: 0,
+    },
+    item: {
+        paddingVertical: 10,
+        paddingHorizontal: 15,
+        borderRadius: 10,
+        marginHorizontal: 5,
+    },
+    yearLabel: {
+        fontSize: 18,
+        fontFamily: "Sora-Bold",
+        marginBottom: 10,
+    },
+    daysGrid: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        justifyContent: "center",
+    },
+    dayItem: {
+        width: 40,
+        height: 40,
+        borderRadius: 10,
+        justifyContent: "center",
+        alignItems: "center",
+        margin: 5,
+    },
+    yearContainer: {
+        padding: 20,
+    },
+    searchInput: {
+        borderWidth: 1,
+        borderRadius: 10,
+        paddingHorizontal: 10,
+        marginBottom: 10,
+    },
+    yearItem: {
+        paddingVertical: 10,
+        paddingHorizontal: 15,
+        borderRadius: 10,
+        marginVertical: 5,
+    },
+});


### PR DESCRIPTION
## Summary
- refactor `DatePicker` to display days in a matrix and show year selection in a separate bottom sheet
- update `RangeDatePicker` with the same layout and paginated year search

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7e978090832ab99ed671a779776d